### PR TITLE
修复Chrome扩展资源加载问题

### DIFF
--- a/extension/build.config.js
+++ b/extension/build.config.js
@@ -1,0 +1,41 @@
+import { defineConfig } from 'vite'
+import vue from '@vitejs/plugin-vue'
+import { resolve } from 'path'
+import { crx } from '@crxjs/vite-plugin'
+import manifest from './manifest.json'
+
+export default defineConfig({
+  plugins: [
+    vue(),
+    crx({ manifest })
+  ],
+  resolve: {
+    alias: {
+      '@': resolve(__dirname, 'src')
+    }
+  },
+  build: {
+    rollupOptions: {
+      input: {
+        popup: resolve(__dirname, 'popup/index.html'),
+        options: resolve(__dirname, 'options/index.html')
+      },
+      output: {
+        manualChunks(id) {
+          if (id.includes('node_modules')) {
+            return 'vendor'
+          }
+        },
+        assetFileNames: (assetInfo) => {
+          const extType = assetInfo.name.split('.').pop()
+          if (/png|jpe?g|svg|gif|webp/.test(extType)) {
+            return `assets/[name]-[hash][extname]`
+          }
+          return `assets/[name]-[hash][extname]`
+        }
+      }
+    },
+    outDir: 'dist',
+    emptyOutDir: true
+  }
+})

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,0 +1,63 @@
+{
+  "manifest_version": 3,
+  "name": "智能书签助手",
+  "version": "0.1.0",
+  "description": "一款跨浏览器的智能化书签管理插件，以侧边栏形式提供便捷访问、自动分类和个性化管理书签能力",
+  "action": {
+    "default_icon": "./assets/icon-512.png",
+    "default_popup": "./dist/popup/index.html"
+  },
+  "options_ui": {
+    "page": "./dist/options/index.html",
+    "open_in_tab": true
+  },
+  "background": {
+    "service_worker": "./dist/background/index.mjs"
+  },
+  "icons": {
+    "16": "./assets/icon-16.png",
+    "48": "./assets/icon-48.png",
+    "128": "./assets/icon-128.png",
+    "512": "./assets/icon-512.png"
+  },
+  "permissions": [
+    "tabs",
+    "storage",
+    "activeTab",
+    "bookmarks",
+    "unlimitedStorage",
+    "favicon"
+  ],
+  "host_permissions": [
+    "*://*/*"
+  ],
+  "content_scripts": [
+    {
+      "matches": [
+        "<all_urls>"
+      ],
+      "js": [
+        "dist/contentScripts/index.global.js"
+      ],
+      "css": [
+        "dist/contentScripts/style.css"
+      ]
+    }
+  ],
+  "web_accessible_resources": [
+    {
+      "resources": [
+        "assets/icon-16.png",
+        "assets/icon-48.png", 
+        "assets/icon-128.png",
+        "assets/icon-512.png"
+      ],
+      "matches": [
+        "<all_urls>"
+      ]
+    }
+  ],
+  "content_security_policy": {
+    "extension_pages": "script-src 'self'; object-src 'self'"
+  }
+}


### PR DESCRIPTION
解决Chrome扩展图标和资源加载问题：

1. 更新Vite构建配置，确保资源正确处理
2. 修改manifest.json中的资源路径
3. 优化web_accessible_resources配置

建议检查并测试扩展加载情况。